### PR TITLE
fix duplicate `html` property in `Trac` app

### DIFF
--- a/share/apps.json
+++ b/share/apps.json
@@ -3639,7 +3639,6 @@
 		"Trac": {
 			"website": "trac.edgewall.org",
 			"cats": [ 13 ],
-			"html": "<a id=\"tracpowered",
 			"html": [ "<a id=\"tracpowered", "Powered by <a href=\"[^\"]*\"><strong>Trac(?:[ /]([\\d.]+))?\\;version:\\1" ],
 			"implies": "Python"
 		},


### PR DESCRIPTION
In: `Trac` app is two property with the same name `html` one is string and one is array of strings:
            "html": "<a id=\"tracpowered",
            "html": [ "<a id=\"tracpowered", "Powered by <a href=\"[^\"]*\"><strong>Trac(?:[ /]([\\d.]+))?\\;version:\\1" ],