### PR TITLE
Add simple JSON validator Travis CI Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 
 build/*
 
+npm-debug.log
+
 node_modules/*
 
 drivers/npm/node_modules/
+
+drivers/npm/npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+﻿language: node_js
+node_js:
+  - "0.10"
+before_install:
+  - export WAPPALYZER_ROOT=$TRAVIS_BUILD_DIR
+  - export PATH=$PATH:$TRAVIS_BUILD_DIR/bin
+install:
+  - sudo apt-get update -y
+  - sudo apt-get install -y curl zip sudo -y --force-yes
+  - sudo apt-get clean
+  - npm install jsonlint -g
+  - mkdir mozilla && curl -L https://ftp.mozilla.org/pub/mozilla.org/labs/jetpack/jetpack-sdk-latest.tar.gz | tar xvzC mozilla && ln -s $WAPPALYZER_ROOT/mozilla/addon-sdk-*/bin/cfx bin/cfx
+  - mkdir phantomjs && curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 | tar xvjC phantomjs && ln -s $WAPPALYZER_ROOT/phantomjs/phantomjs-*-linux-x86_64/bin/phantomjs bin/phantomjs
+before_script: mkdir build
+script: wappalyzer build
+after_script: ls build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wappalyzer
+# Wappalyzer [![Travis](https://img.shields.io/travis/ElbertF/Wappalyzer.svg?style=flat-square)]()
 
 [Wappalyzer](https://wappalyzer.com/) is a 
 [cross-platform](https://github.com/ElbertF/Wappalyzer/wiki/Drivers) utility that uncovers the 


### PR DESCRIPTION
What this does:

 - Running `npm test` (like Travis CI does) will check for validation on `apps.json` and `schema.json`.
 - I am using Grunt (an NPM package) to test it.
 - More tests can be added; this is just a basic one to catch the most common errors. Most pull requests are to `apps.json`.
 - Grunt can also be used for automated building, etc.
 - All pull requests will automatically be tested and their pass/fail will be shown in the pull request,

What will need to be done if this is merged:

 - This repo will need to be registered on Travis CI (free). I already have added the `.travis.yml` file, so it should start working immediately.
 - A badge should be added to the top of the README. The badge won't work until Wappalyzer is registered on Travis CI. It is the passing/failing badge: `[![Travis](https://img.shields.io/travis/ElbertF/Wappalyzer.svg?style=flat-square)]()`.